### PR TITLE
Add Bing Clarity code insert.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 === TFnet Code ===
 Contributors: thetitan
-Stable tag: 1.0.0
-Tested up to: 6.2.0
+Stable tag: 1.1.0
+Tested up to: 6.4.2
 Requires at least: 6.0.0
 
 A plug-in to maintain code across WordPress versions on TitanFusion.net

--- a/tfnet-code.php
+++ b/tfnet-code.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @package TFnet_Code
- * @version 1.0.2
+ * @version 1.1.0
  */
 /*
 Plugin Name:TitanFusion.net Code
 Plugin URI: https://www.titanfusion.net/projects/tfnet-code
 Description: This plug-in will add any code necessary for TitanFusion.net to properly function. The intent is to maintain the additional code across theme and WordPress version updates.
 Author: Alexandar I. Tzanov
-Version: 1.0.2
+Version: 1.1.0
 Author URI: https://www.alexandartzanov.com/
 */
 
@@ -53,6 +53,28 @@ if ( ! function_exists( 'tfnet_client_cache' ) ) :
 	}
 endif;
 
+// Add Bing Clarity code (site statistics and performance)
+if ( ! function_exists( 'add_bing_clarity' ) ) :
+	/**
+	 * @name bing_clarity
+	 * @description Add Bing Clarity site statistics and performance code to page header
+	 */
+	function add_bing_clarity() {
+		if ( defined( 'BING_CLARITY_ID' ) ) {
+			$site_id = BING_CLARITY_ID;
+			echo <<<EOL
+<script type="text/javascript">
+	(function(c,l,a,r,i,t,y){
+		c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+		t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+		y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+	})(window, document, "clarity", "script", "$site_id");
+</script>
+EOL;
+		}
+	}
+endif;
+
 // Add Filters
 add_filter( 'jetpack_remove_login_form', '__return_true' );
 add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
@@ -60,3 +82,4 @@ add_filter( 'wp_headers', 'tfnet_client_cache', 100, 2);
 
 // Add Actions
 add_action( 'phpmailer_init', 'send_smtp_email' );
+add_action( 'wp_head', 'add_bing_clarity', 100 );

--- a/tfnet-code.php
+++ b/tfnet-code.php
@@ -1,20 +1,16 @@
 <?php
 /**
  * @package TFnet_Code
- * @version 1.0.0
+ * @version 1.0.1
  */
 /*
 Plugin Name:TitanFusion.net Code
 Plugin URI: https://www.titanfusion.net/projects/tfnet-code
 Description: This plug-in will add any code necessary for TitanFusion.net to properly function. The intent is to maintain the additional code across theme and WordPress version updates.
 Author: Alexandar I. Tzanov
-Version: 1.0.0
+Version: 1.0.1
 Author URI: https://www.alexandartzanov.com/
 */
-
-// Secure login form
-add_filter( 'jetpack_remove_login_form', '__return_true' );
-add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
 
 // Mail hook to phpmailer
 if ( ! function_exists( 'send_smtp_email' ) ) :
@@ -38,8 +34,6 @@ if ( ! function_exists( 'send_smtp_email' ) ) :
 
 endif;
 
-add_action( 'phpmailer_init', 'send_smtp_email' );
-
 // Enable client caching of content.
 if ( ! function_exists( 'tfnet_client_cache' ) ) :
 	/**
@@ -47,22 +41,24 @@ if ( ! function_exists( 'tfnet_client_cache' ) ) :
 	 * @description Enable client caching. Disabled by default by WordPress for compatibility with third-party cache plug-ins. Will run last.
 	 * @return array
 	 */
-	function tfnet_client_cache( $headers ) {
+	function tfnet_client_cache( $headers = '' ) {
 		global $wp;
 
-		$current_request_path = $wp->requet;
+		$current_request_path = $wp->request;
 
-		// Update headers if not viewing WP admin dashboard
-		if ( '' !== $current_request_path ) {
-			$current_request_path = trim( $current_request_path, '/' );
-
-			if ( 'wp-admin' !== $current_request_path ) {
-				$headers[ 'Cache-Control' ] = 'private, max-age=365';
-			}
+		// Update headers if not viewing WordPress admin dashboard
+		if ( !empty( $current_request_path) && !strpos( $current_request_path, 'wp-admin' ) ) {
+			$headers[ 'Cache-Control' ] = 'private, max-age=365';
 		}
 		
 		return $headers;
 	}
 endif;
 
+// Add Filters
+add_filter( 'jetpack_remove_login_form', '__return_true' );
+add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
 add_filter( 'wp_headers', 'tfnet_client_cache', 100, 1);
+
+// Add Actions
+add_action( 'phpmailer_init', 'send_smtp_email' );

--- a/tfnet-code.php
+++ b/tfnet-code.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @package TFnet_Code
- * @version 1.0.1
+ * @version 1.0.2
  */
 /*
 Plugin Name:TitanFusion.net Code
 Plugin URI: https://www.titanfusion.net/projects/tfnet-code
 Description: This plug-in will add any code necessary for TitanFusion.net to properly function. The intent is to maintain the additional code across theme and WordPress version updates.
 Author: Alexandar I. Tzanov
-Version: 1.0.1
+Version: 1.0.2
 Author URI: https://www.alexandartzanov.com/
 */
 
@@ -41,13 +41,11 @@ if ( ! function_exists( 'tfnet_client_cache' ) ) :
 	 * @description Enable client caching. Disabled by default by WordPress for compatibility with third-party cache plug-ins. Will run last.
 	 * @return array
 	 */
-	function tfnet_client_cache( $headers = '' ) {
-		global $wp;
-
+	function tfnet_client_cache( $headers, $wp ) {
 		$current_request_path = $wp->request;
 
 		// Update headers if not viewing WordPress admin dashboard
-		if ( !empty( $current_request_path) && !strpos( $current_request_path, 'wp-admin' ) ) {
+		if ( ! empty( $current_request_path) && ! is_admin() ) {
 			$headers[ 'Cache-Control' ] = 'private, max-age=365';
 		}
 		
@@ -58,7 +56,7 @@ endif;
 // Add Filters
 add_filter( 'jetpack_remove_login_form', '__return_true' );
 add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
-add_filter( 'wp_headers', 'tfnet_client_cache', 100, 1);
+add_filter( 'wp_headers', 'tfnet_client_cache', 100, 2);
 
 // Add Actions
 add_action( 'phpmailer_init', 'send_smtp_email' );


### PR DESCRIPTION
This update introduces the following changes:

1. The action and filter hooks were moved to the end of the file.
2. The cache control has been changed to accept the WP object as a parameter of the "tfnet_client_cache" function.
3. Add a new action hook - "add_bing_clarity", due to the Site kit by Google plugin being removed from TitanFusion.net.